### PR TITLE
Show OpenAPI documentation for API tags

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -42,7 +42,7 @@ def add_exception_handler(
 
 
 def initialize_fast_app(gx_app):
-    app = FastAPI()
+    app = FastAPI(openapi_tags=api_tags_metadata)
 
     add_exception_handler(app)
     wsgi_handler = WSGIMiddleware(gx_app)


### PR DESCRIPTION
After merging #11056, I noticed that the `api_tags_metadata` was not passed to the FastAPI constructor.
This should fix it and show the documentation for tags like this:

![image](https://user-images.githubusercontent.com/46503462/104010516-e7cb0980-51ac-11eb-92b4-7c093734dda0.png)
